### PR TITLE
feat: add Meta embedded signup coexistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -287,6 +287,14 @@ AUTHENTICATION_API_KEY=429683C4C977415CAAFCCE10F7D57E11
 AUTHENTICATION_EXPOSE_IN_FETCH_INSTANCES=true
 LANGUAGE=en
 
+# Meta WhatsApp Cloud API
+META_APP_ID=
+META_APP_SECRET=
+META_GRAPH_VERSION=v21.0
+META_VERIFY_TOKEN=
+META_REDIRECT_URI=https://your-domain.com/v1/meta/callback/{instanceId}
+ENCRYPTION_KEY=
+
 # Define a global proxy to be used if the instance does not have one
 # PROXY_HOST=
 # PROXY_PORT=80

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 Evolution API began as a WhatsApp controller API based on [CodeChat](https://github.com/code-chat-br/whatsapp-api), which in turn implemented the [Baileys](https://github.com/WhiskeySockets/Baileys) library. While originally focused on WhatsApp, Evolution API has grown into a comprehensive platform supporting multiple messaging services and integrations. We continue to acknowledge CodeChat for laying the groundwork.
 
+For instrucciones sobre la coexistencia con Meta WhatsApp Cloud API mediante Embedded Signup, consulta [docs/INTEGRATION_GUIDE.md](docs/INTEGRATION_GUIDE.md) y la [checklist de integración](docs/INTEGRATION_CHECKLIST.md).
+
 Today, Evolution API is not limited to WhatsApp. It integrates with various platforms such as Typebot, Chatwoot, Dify, and OpenAI, offering a broad array of functionalities beyond messaging. Evolution API supports both the Baileys-based WhatsApp API and the official WhatsApp Business API, with upcoming support for Instagram and Messenger.
 
 ## Looking for a Lightweight Version?

--- a/docs/INTEGRATION_CHECKLIST.md
+++ b/docs/INTEGRATION_CHECKLIST.md
@@ -1,0 +1,11 @@
+# Integration Checklist: Meta Embedded Signup
+
+- [ ] Configure environment variables: `META_APP_ID`, `META_APP_SECRET`, `META_GRAPH_VERSION`, `META_VERIFY_TOKEN`, `META_REDIRECT_URI`, `ENCRYPTION_KEY`.
+- [ ] Run Prisma migrations to ensure `Instance` model contains coexistence fields.
+- [ ] Start signup via `POST /v1/meta/start-signup` and complete OAuth flow.
+- [ ] Verify callback persists tokens and instance metadata.
+- [ ] Configure Meta webhook to `/v1/meta/webhook/{instanceId}` and verify with `GET` request.
+- [ ] Ensure webhook POST requests include valid `X-Hub-Signature-256` header.
+- [ ] Send message through Graph API using stored `phoneNumberId` and access token.
+- [ ] Test token refresh with `POST /v1/meta/token/refresh/{instanceId}`.
+- [ ] Confirm Baileys instances continue to operate normally.

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1,0 +1,74 @@
+# Guía de Integración: Evolution API + Meta Coexistencia (Embedded Signup)
+
+## 1. Contexto
+Este documento describe cómo integrar la coexistencia de WhatsApp Business API (WABA) mediante el flujo **Embedded Signup de Meta** dentro de Evolution API, manteniendo soporte para múltiples conectores (Baileys y WABA).
+
+## 2. Requisitos Previos
+- Cuenta de Meta aprobada como **Proveedor de Servicios (BSP)** bajo la app **Pedylo Latam**.
+- Evolution API desplegado (Node.js 20, TypeScript, Express, Prisma, MariaDB).
+- Variables de entorno Meta configuradas:
+  - `META_GRAPH_VERSION`
+  - `META_APP_ID`
+  - `META_APP_SECRET`
+  - `META_VERIFY_TOKEN`
+  - `META_REDIRECT_URI`
+  - `ENCRYPTION_KEY`
+
+## 3. Flujo de Integración (Embedded Signup)
+1. Cliente inicia el proceso desde Evolution API → se abre ventana de Meta Embedded Signup.
+2. Meta devuelve:
+   - `access_token` (de corta duración → se intercambia por refresh token).
+   - `business_id`
+   - `waba_id`
+   - `phone_number_id`
+3. Evolution API guarda esta información en la BD (`Instance` extendido).
+4. Webhooks configurados en Meta apuntan a `/v1/meta/webhook/{instanceId}`.
+
+## 4. Cambios en Evolution API
+### a. Modelos de Base de Datos
+Extender `Instance` para incluir:
+- `providerType`
+- `accessToken`
+- `refreshToken`
+- `businessId`
+- `wabaId`
+- `phoneNumberId`
+- `phoneNumber`
+- `status`
+
+### b. Endpoints Nuevos
+- `POST /v1/meta/start-signup` → inicia el flujo embebido de Meta.
+- `GET /v1/meta/callback` → procesa el `code` devuelto por Meta.
+- `GET /v1/meta/webhook/:instanceId` → verificación del webhook.
+- `POST /v1/meta/webhook/:instanceId` → recepción de mensajes y eventos.
+
+### c. Webhooks
+- `GET /v1/meta/webhook/:instanceId` → verificación con `META_VERIFY_TOKEN`.
+- `POST /v1/meta/webhook/:instanceId` → recepción de mensajes y eventos (firmados con `META_APP_SECRET`).
+
+### d. Conectores
+- **Baileys** (conexión vía QR).
+- **WABA Coexistencia** (conexión vía Meta Cloud API).
+- Cada instancia puede definir `providerType`.
+
+## 5. Seguridad
+- Validar cabecera `X-Hub-Signature-256` para webhooks.
+- Guardar tokens cifrados en BD con AES‑256‑GCM.
+- Usar API Keys (`x-api-key`) para endpoints de envío.
+
+## 6. Checklist de Implementación
+- [ ] Definir modelos Prisma actualizados.
+- [ ] Crear migración BD.
+- [ ] Agregar endpoints de coexistencia.
+- [ ] Implementar flujo OAuth Embedded Signup.
+- [ ] Configurar webhooks en Meta Developer.
+- [ ] Probar coexistencia con cuentas demo y reales.
+
+## 7. Documentación de Referencia
+- [Meta for Developers – WhatsApp Embedded Signup](https://developers.facebook.com/docs/whatsapp/business-management-api/get-started/embedded-signup/)
+- [Meta Cloud API](https://developers.facebook.com/docs/whatsapp/cloud-api/)
+- [Evolution API](https://github.com/EvolutionAPI/evolution-api)
+
+## 8. Próximos Pasos
+1. Añadir cambios en el código base de Evolution API.
+2. Publicar documentación en `docs/INTEGRATION_GUIDE.md`.

--- a/prisma/mysql-migrations/20250615120000_add_meta_columns/migration.sql
+++ b/prisma/mysql-migrations/20250615120000_add_meta_columns/migration.sql
@@ -1,0 +1,15 @@
+ALTER TABLE `Instance`
+  ADD COLUMN `providerType` VARCHAR(32) NOT NULL DEFAULT 'baileys',
+  ADD COLUMN `wabaId` VARCHAR(255),
+  ADD COLUMN `phoneNumberId` VARCHAR(255),
+  ADD COLUMN `phoneNumber` VARCHAR(50),
+  ADD COLUMN `accessToken` TEXT,
+  ADD COLUMN `refreshToken` TEXT,
+  ADD COLUMN `tokenExpiresAt` DATETIME NULL,
+  ADD COLUMN `webhookUrl` TEXT,
+  ADD COLUMN `webhookVerifyToken` VARCHAR(255),
+  ADD COLUMN `status` VARCHAR(32) NOT NULL DEFAULT 'disconnected';
+
+CREATE UNIQUE INDEX `Instance_phoneNumber_key` ON `Instance`(`phoneNumber`);
+CREATE INDEX `Instance_wabaId_idx` ON `Instance`(`wabaId`);
+CREATE INDEX `Instance_phoneNumberId_idx` ON `Instance`(`phoneNumberId`);

--- a/prisma/mysql-schema.prisma
+++ b/prisma/mysql-schema.prisma
@@ -60,6 +60,17 @@ enum DifyBotType {
   workflow
 }
 
+enum ProviderType {
+  baileys
+  meta
+}
+
+enum WaInstanceStatus {
+  connected
+  disconnected
+  pending
+}
+
 model Instance {
   id                      String                   @id @default(cuid())
   name                    String                   @unique @db.VarChar(255)
@@ -71,6 +82,16 @@ model Instance {
   number                  String?                  @db.VarChar(100)
   businessId              String?                  @db.VarChar(100)
   token                   String?                  @db.VarChar(255)
+  providerType            ProviderType             @default(baileys)
+  wabaId                  String?                  @db.VarChar(255)
+  phoneNumberId           String?                  @db.VarChar(255)
+  phoneNumber             String?                  @unique @db.VarChar(50)
+  accessToken             String?                  @db.Text
+  refreshToken            String?                  @db.Text
+  tokenExpiresAt          DateTime?                @db.Timestamp
+  webhookUrl              String?                  @db.Text
+  webhookVerifyToken      String?                  @db.VarChar(255)
+  status                  WaInstanceStatus         @default(disconnected)
   clientName              String?                  @db.VarChar(100)
   disconnectionReasonCode Int?                     @db.Int
   disconnectionObject     Json?                    @db.Json
@@ -107,6 +128,8 @@ model Instance {
   FlowiseSetting          FlowiseSetting?
   Pusher                  Pusher?
   N8n                     N8n[]
+  @@index([wabaId])
+  @@index([phoneNumberId])
 }
 
 model Session {

--- a/prisma/postgresql-migrations/20250615120000_add_meta_columns/migration.sql
+++ b/prisma/postgresql-migrations/20250615120000_add_meta_columns/migration.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "Instance"
+  ADD COLUMN "providerType" VARCHAR(32) DEFAULT 'baileys',
+  ADD COLUMN "wabaId" VARCHAR(255),
+  ADD COLUMN "phoneNumberId" VARCHAR(255),
+  ADD COLUMN "phoneNumber" VARCHAR(50),
+  ADD COLUMN "accessToken" TEXT,
+  ADD COLUMN "refreshToken" TEXT,
+  ADD COLUMN "tokenExpiresAt" TIMESTAMP,
+  ADD COLUMN "webhookUrl" TEXT,
+  ADD COLUMN "webhookVerifyToken" VARCHAR(255),
+  ADD COLUMN "status" VARCHAR(32) DEFAULT 'disconnected';
+
+CREATE UNIQUE INDEX "Instance_phoneNumber_key" ON "Instance"("phoneNumber");
+CREATE INDEX "Instance_wabaId_idx" ON "Instance"("wabaId");
+CREATE INDEX "Instance_phoneNumberId_idx" ON "Instance"("phoneNumberId");

--- a/src/api/controllers/meta.controller.ts
+++ b/src/api/controllers/meta.controller.ts
@@ -1,0 +1,98 @@
+import { prismaRepository } from '@api/server.module';
+import { EmbeddedSignupService } from '@api/services/embedded-signup.service';
+import { MetaCoexistenceService } from '@api/services/meta-coexistence.service';
+import { WebhookManagerService } from '@api/services/webhook-manager.service';
+import { Integration } from '@api/types/wa.types';
+import { decrypt, encrypt } from '@utils/crypto';
+import { Request, Response } from 'express';
+
+const embed = new EmbeddedSignupService();
+const meta = new MetaCoexistenceService();
+const webhookManager = new WebhookManagerService();
+
+export async function startSignup(req: Request, res: Response) {
+  const instanceId = String(req.body.instanceId || req.params.instanceId || 'default-instance');
+  const redirectTemplate = process.env.META_REDIRECT_URI || 'https://your-domain.com/v1/meta/callback/{instanceId}';
+  const redirectUri = redirectTemplate.replace('{instanceId}', instanceId);
+  const { url, state } = embed.buildSignupUrl(instanceId, redirectUri);
+  res.json({ signupUrl: url, state });
+}
+
+export async function callbackHandler(req: Request, res: Response) {
+  const { code, state } = req.query as any;
+  if (!state || !embed.validateState(String(state))) return res.status(400).send('invalid state');
+  const instanceId = String(state).split(':')[0];
+  try {
+    const redirectTemplate = process.env.META_REDIRECT_URI || 'https://your-domain.com/v1/meta/callback/{instanceId}';
+    const redirectUri = redirectTemplate.replace('{instanceId}', instanceId);
+    const tokenData = await embed.exchangeCode(String(code), redirectUri);
+    const accessToken = tokenData.access_token;
+    const refreshToken = tokenData.refresh_token;
+    const debug = await meta.debugToken(accessToken);
+    const businesses = await meta.fetchBusinessAccounts(accessToken);
+    const business = businesses.data?.[0];
+    const businessId = business?.id;
+    const wabaId = business?.id;
+    const phones = await meta.getPhoneNumbers(wabaId, accessToken);
+    const phone = phones.data?.[0];
+    const phoneNumberId = phone?.id;
+    const phoneNumber = phone?.display_phone_number;
+    const encryptedAccess = encrypt(accessToken);
+    const encryptedRefresh = refreshToken ? encrypt(refreshToken) : null;
+    const expiresAt = tokenData.expires_in ? new Date(Date.now() + tokenData.expires_in * 1000) : null;
+    const webhookUrl = `/v1/meta/webhook/${instanceId}`;
+    await prismaRepository.instance.update({
+      where: { id: instanceId },
+      data: {
+        providerType: 'meta',
+        integration: Integration.WHATSAPP_BUSINESS,
+        businessId,
+        wabaId,
+        phoneNumberId,
+        phoneNumber,
+        accessToken: encryptedAccess,
+        refreshToken: encryptedRefresh,
+        tokenExpiresAt: expiresAt,
+        webhookUrl,
+        webhookVerifyToken: process.env.META_VERIFY_TOKEN,
+        status: 'connected',
+      },
+    });
+    res.json({ status: 'ok', instanceId, debug });
+  } catch (err: any) {
+    res.status(500).json({ error: err.response?.data || err.message || err });
+  }
+}
+
+export function verifyWebhook(req: Request, res: Response) {
+  if (req.query['hub.verify_token'] === process.env.META_VERIFY_TOKEN) {
+    return res.send(req.query['hub.challenge']);
+  }
+  return res.status(403).send('forbidden');
+}
+
+export async function receiveWebhook(req: Request, res: Response) {
+  const instanceId = req.params.instanceId || 'default-instance';
+  const body = (req as any).rawBody || req.body;
+  webhookManager.enqueue(instanceId, body);
+  res.sendStatus(200);
+}
+
+export async function refreshToken(req: Request, res: Response) {
+  const instanceId = req.params.instanceId;
+  try {
+    const instance = await prismaRepository.instance.findFirst({ where: { id: instanceId } });
+    if (!instance?.refreshToken) return res.status(404).send('instance not found');
+    const currentRefresh = decrypt(instance.refreshToken);
+    const data = await meta.refreshAccessToken(currentRefresh);
+    const encrypted = encrypt(data.access_token);
+    const expiresAt = data.expires_in ? new Date(Date.now() + data.expires_in * 1000) : null;
+    await prismaRepository.instance.update({
+      where: { id: instanceId },
+      data: { accessToken: encrypted, tokenExpiresAt: expiresAt },
+    });
+    res.json({ status: 'ok' });
+  } catch (err: any) {
+    res.status(500).json({ error: err.response?.data || err.message || err });
+  }
+}

--- a/src/api/middleware/verifyMetaSignature.ts
+++ b/src/api/middleware/verifyMetaSignature.ts
@@ -1,0 +1,24 @@
+import crypto from 'crypto';
+import { NextFunction, Request, Response } from 'express';
+
+export function verifyMetaSignature(req: Request, res: Response, next: NextFunction) {
+  const sig = (req.headers['x-hub-signature-256'] || '') as string;
+  const appSecret = process.env.META_APP_SECRET || '';
+  if (!sig || !appSecret) {
+    return res.status(401).send('signature missing or app secret not configured');
+  }
+  const raw = (req as any).rawBody || JSON.stringify(req.body);
+  const hmac = crypto.createHmac('sha256', appSecret);
+  hmac.update(raw, 'utf8');
+  const expected = `sha256=${hmac.digest('hex')}`;
+  try {
+    const a = Buffer.from(expected, 'utf8');
+    const b = Buffer.from(sig, 'utf8');
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+      return res.status(401).send('invalid signature');
+    }
+  } catch {
+    return res.status(401).send('invalid signature');
+  }
+  next();
+}

--- a/src/api/routes/index.router.ts
+++ b/src/api/routes/index.router.ts
@@ -18,6 +18,7 @@ import { ChatRouter } from './chat.router';
 import { GroupRouter } from './group.router';
 import { InstanceRouter } from './instance.router';
 import { LabelRouter } from './label.router';
+import { MetaRouter } from './meta.router';
 import { ProxyRouter } from './proxy.router';
 import { MessageRouter } from './sendMessage.router';
 import { SettingsRouter } from './settings.router';
@@ -91,6 +92,7 @@ router
   .use('/settings', new SettingsRouter(...guards).router)
   .use('/proxy', new ProxyRouter(...guards).router)
   .use('/label', new LabelRouter(...guards).router)
+  .use('/meta', new MetaRouter(...guards).router)
   .use('', new ChannelRouter(configService, ...guards).router)
   .use('', new EventRouter(configService, ...guards).router)
   .use('', new ChatbotRouter(...guards).router)

--- a/src/api/routes/meta.router.ts
+++ b/src/api/routes/meta.router.ts
@@ -1,0 +1,16 @@
+import { RouterBroker } from '@api/abstract/abstract.router';
+import * as MetaCtrl from '@api/controllers/meta.controller';
+import { verifyMetaSignature } from '@api/middleware/verifyMetaSignature';
+import { RequestHandler, Router } from 'express';
+
+export class MetaRouter extends RouterBroker {
+  constructor(...guards: RequestHandler[]) {
+    super();
+    this.router.post('/start-signup', ...guards, MetaCtrl.startSignup);
+    this.router.get('/callback/:instanceId', MetaCtrl.callbackHandler);
+    this.router.get('/webhook/:instanceId', MetaCtrl.verifyWebhook);
+    this.router.post('/webhook/:instanceId', verifyMetaSignature, MetaCtrl.receiveWebhook);
+    this.router.post('/token/refresh/:instanceId', ...guards, MetaCtrl.refreshToken);
+  }
+  public readonly router: Router = Router();
+}

--- a/src/api/services/embedded-signup.service.ts
+++ b/src/api/services/embedded-signup.service.ts
@@ -1,0 +1,37 @@
+import crypto from 'crypto';
+
+import { MetaCoexistenceService } from './meta-coexistence.service';
+
+export class EmbeddedSignupService {
+  private readonly stateStore = new Map<string, number>();
+
+  private generateState(instanceId: string) {
+    const state = `${instanceId}:${crypto.randomBytes(8).toString('hex')}`;
+    this.stateStore.set(state, Date.now());
+    return state;
+  }
+
+  validateState(state: string) {
+    const created = this.stateStore.get(state);
+    if (!created) return false;
+    const valid = Date.now() - created < 5 * 60 * 1000;
+    this.stateStore.delete(state);
+    return valid;
+  }
+
+  buildSignupUrl(instanceId: string, redirectUri: string) {
+    const state = this.generateState(instanceId);
+    const appId = process.env.META_APP_ID;
+    const scopes = ['whatsapp_business_management', 'whatsapp_business_messaging', 'business_management'].join(',');
+    const version = process.env.META_GRAPH_VERSION || 'v21.0';
+    const url = `https://www.facebook.com/${version}/dialog/oauth?client_id=${appId}&redirect_uri=${encodeURIComponent(
+      redirectUri,
+    )}&scope=${encodeURIComponent(scopes)}&state=${encodeURIComponent(state)}`;
+    return { url, state };
+  }
+
+  async exchangeCode(code: string, redirectUri: string) {
+    const meta = new MetaCoexistenceService();
+    return meta.exchangeCodeForToken(code, redirectUri);
+  }
+}

--- a/src/api/services/meta-business-instance.service.ts
+++ b/src/api/services/meta-business-instance.service.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const GRAPH_BASE = 'https://graph.facebook.com';
+const API_VERSION = process.env.META_GRAPH_VERSION || 'v21.0';
+
+export class MetaBusinessInstanceService {
+  async sendMessage(phoneNumberId: string, accessToken: string, payload: any) {
+    const url = `${GRAPH_BASE}/${API_VERSION}/${phoneNumberId}/messages`;
+    await axios.post(url, payload, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+  }
+}

--- a/src/api/services/meta-coexistence.service.ts
+++ b/src/api/services/meta-coexistence.service.ts
@@ -1,0 +1,52 @@
+import axios from 'axios';
+
+const GRAPH_BASE = 'https://graph.facebook.com';
+const API_VERSION = process.env.META_GRAPH_VERSION || 'v21.0';
+
+export class MetaCoexistenceService {
+  async exchangeCodeForToken(code: string, redirectUri: string) {
+    const res = await axios.get(`${GRAPH_BASE}/${API_VERSION}/oauth/access_token`, {
+      params: {
+        client_id: process.env.META_APP_ID,
+        client_secret: process.env.META_APP_SECRET,
+        redirect_uri: redirectUri,
+        code,
+      },
+    });
+    return res.data;
+  }
+
+  async debugToken(accessToken: string) {
+    const appToken = `${process.env.META_APP_ID}|${process.env.META_APP_SECRET}`;
+    const res = await axios.get(`${GRAPH_BASE}/${API_VERSION}/debug_token`, {
+      params: { input_token: accessToken, access_token: appToken },
+    });
+    return res.data;
+  }
+
+  async fetchBusinessAccounts(userAccessToken: string) {
+    const res = await axios.get(`${GRAPH_BASE}/${API_VERSION}/me/owned_businesses`, {
+      params: { access_token: userAccessToken },
+    });
+    return res.data;
+  }
+
+  async getPhoneNumbers(wabaId: string, accessToken: string) {
+    const res = await axios.get(`${GRAPH_BASE}/${API_VERSION}/${wabaId}/phone_numbers`, {
+      params: { access_token: accessToken },
+    });
+    return res.data;
+  }
+
+  async refreshAccessToken(refreshToken: string) {
+    const res = await axios.get(`${GRAPH_BASE}/${API_VERSION}/oauth/access_token`, {
+      params: {
+        grant_type: 'fb_exchange_token',
+        client_id: process.env.META_APP_ID,
+        client_secret: process.env.META_APP_SECRET,
+        fb_exchange_token: refreshToken,
+      },
+    });
+    return res.data;
+  }
+}

--- a/src/api/services/monitor.service.ts
+++ b/src/api/services/monitor.service.ts
@@ -234,6 +234,8 @@ export class WAMonitoringService {
           token: data.hash,
           clientName: clientName,
           businessId: data.businessId,
+          providerType: data.providerType || 'baileys',
+          status: 'disconnected',
         },
       });
     } catch (error) {
@@ -250,6 +252,11 @@ export class WAMonitoringService {
   }
 
   private async setInstance(instanceData: InstanceDto) {
+    if (!instanceData.integration) {
+      instanceData.integration =
+        instanceData.providerType === 'meta' ? Integration.WHATSAPP_BUSINESS : Integration.WHATSAPP_BAILEYS;
+    }
+
     const instance = channelController.init(instanceData, {
       configService: this.configService,
       eventEmitter: this.eventEmitter,

--- a/src/api/services/webhook-manager.service.ts
+++ b/src/api/services/webhook-manager.service.ts
@@ -1,0 +1,13 @@
+import EventEmitter from 'events';
+
+export class WebhookManagerService {
+  private emitter = new EventEmitter();
+
+  on(listener: (data: { instanceId: string; body: any }) => void) {
+    this.emitter.on('webhook', listener);
+  }
+
+  enqueue(instanceId: string, body: any) {
+    this.emitter.emit('webhook', { instanceId, body });
+  }
+}

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -271,6 +271,14 @@ export type Dify = { ENABLED: boolean };
 export type N8n = { ENABLED: boolean };
 export type Evoai = { ENABLED: boolean };
 export type Flowise = { ENABLED: boolean };
+export type Meta = {
+  APP_ID: string;
+  APP_SECRET: string;
+  GRAPH_VERSION: string;
+  VERIFY_TOKEN: string;
+  REDIRECT_URI: string;
+  ENCRYPTION_KEY: string;
+};
 
 export type S3 = {
   ACCESS_KEY: string;
@@ -313,6 +321,7 @@ export interface Env {
   N8N: N8n;
   EVOAI: Evoai;
   FLOWISE: Flowise;
+  META: Meta;
   CACHE: CacheConf;
   S3?: S3;
   AUTHENTICATION: Auth;
@@ -629,6 +638,14 @@ export class ConfigService {
       },
       FLOWISE: {
         ENABLED: process.env?.FLOWISE_ENABLED === 'true',
+      },
+      META: {
+        APP_ID: process.env.META_APP_ID || '',
+        APP_SECRET: process.env.META_APP_SECRET || '',
+        GRAPH_VERSION: process.env.META_GRAPH_VERSION || 'v21.0',
+        VERIFY_TOKEN: process.env.META_VERIFY_TOKEN || '',
+        REDIRECT_URI: process.env.META_REDIRECT_URI || '',
+        ENCRYPTION_KEY: process.env.ENCRYPTION_KEY || '',
       },
       CACHE: {
         REDIS: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,10 @@ async function bootstrap() {
   const prismaRepository = new PrismaRepository(configService);
   await prismaRepository.onModuleInit();
 
+  const rawBodySaver = (req: Request, _res: Response, buf: Buffer) => {
+    (req as any).rawBody = buf.toString();
+  };
+
   app.use(
     cors({
       origin(requestOrigin, callback) {
@@ -52,7 +56,7 @@ async function bootstrap() {
       credentials: configService.get<Cors>('CORS').CREDENTIALS,
     }),
     urlencoded({ extended: true, limit: '136mb' }),
-    json({ limit: '136mb' }),
+    json({ limit: '136mb', verify: rawBodySaver }),
     compression(),
   );
 

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,0 +1,27 @@
+import crypto from 'crypto';
+
+const ALGO = 'aes-256-gcm';
+const key = process.env.ENCRYPTION_KEY || '';
+if (Buffer.byteLength(key) !== 32) {
+  throw new Error('ENCRYPTION_KEY must be 32 bytes');
+}
+const KEY = Buffer.from(key);
+
+export function encrypt(text: string): string {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv(ALGO, KEY, iv);
+  const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, encrypted]).toString('base64');
+}
+
+export function decrypt(enc: string): string {
+  const data = Buffer.from(enc, 'base64');
+  const iv = data.slice(0, 12);
+  const tag = data.slice(12, 28);
+  const encrypted = data.slice(28);
+  const decipher = crypto.createDecipheriv(ALGO, KEY, iv);
+  decipher.setAuthTag(tag);
+  const out = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+  return out.toString('utf8');
+}


### PR DESCRIPTION
## Summary
- add provider type/status enums and supporting services for Meta embedded signup
- persist encrypted tokens and webhook data during signup callback
- document Meta integration checklist and expose new endpoints

## Testing
- `npx prisma migrate dev --schema prisma/mysql-schema.prisma --name add_provider_enums` (fails: Environment variable not found: DATABASE_CONNECTION_URI)
- `npm run lint:check`
- `npm test` (fails: Cannot find module '/workspace/evo-api/test/all.test.ts')
- `npm run build` (fails: Module '"@prisma/client"' has no exported member 'Typebot')
- `npm start` (fails: @prisma/client did not initialize yet)


------
https://chatgpt.com/codex/tasks/task_e_68b9031a3898832396773657fd7facdf